### PR TITLE
Add error when --read_directory is not provided for fuzzy matches

### DIFF
--- a/workflows/amplicon-nf.nf
+++ b/workflows/amplicon-nf.nf
@@ -137,8 +137,7 @@ workflow AMPLICON_NF {
                 1) If you are using implicit (fuzzy) input matching, ensure you are providing the `--read_directory` parameter and that the directory structure / file naming conventions are compatible with the expected patterns as described in https://github.com/artic-network/amplicon-nf/blob/main/docs/usage.md, this is crucial for successful file matching. This is the most common cause of this error being raised.
 
                 2) The samplesheet provided via --input is not empty.
-
-            """
+                """
             )
         }
         .filter { it != null }


### PR DESCRIPTION
<!--
# artic-network/amplicon-nf pull request

Many thanks for contributing to artic-network/amplicon-nf!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/artic-network/amplicon-nf/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/artic-network/amplicon-nf/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
